### PR TITLE
Fix wrong text for short address range and fix change of address

### DIFF
--- a/Z2X-Programmer/Resources/Strings/AppResources.Designer.cs
+++ b/Z2X-Programmer/Resources/Strings/AppResources.Designer.cs
@@ -702,7 +702,7 @@ namespace Z2XProgrammer.Resources.Strings {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Short locomotive addresses (1 - 237).
+        ///   Looks up a localized string similar to Long locomotive addresses (128 - 10239).
         /// </summary>
         public static string DCCAddressModeLong {
             get {
@@ -711,7 +711,7 @@ namespace Z2XProgrammer.Resources.Strings {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Long locomotive addresses (128 - 10239).
+        ///   Looks up a localized string similar to Short locomotive addresses (1 - 127).
         /// </summary>
         public static string DCCAddressModeShort {
             get {

--- a/Z2X-Programmer/Resources/Strings/AppResources.resx
+++ b/Z2X-Programmer/Resources/Strings/AppResources.resx
@@ -240,10 +240,10 @@ The following error has occurred:</value>
   <data name="DCCABCBreakModeRightTrack" xml:space="preserve">
     <value>Stop at higher voltage on right-hand track</value>
   </data>
-  <data name="DCCAddressModeLong" xml:space="preserve">
-    <value>Short locomotive addresses (1 - 237)</value>
-  </data>
   <data name="DCCAddressModeShort" xml:space="preserve">
+    <value>Short locomotive addresses (1 - 127)</value>
+  </data>
+  <data name="DCCAddressModeLong" xml:space="preserve">
     <value>Long locomotive addresses (128 - 10239)</value>
   </data>
   <data name="DCCProgrammingModePOM" xml:space="preserve">


### PR DESCRIPTION
Fix wrong text for short address range and fix change of address after change the Address Mode in the Address section.
The value were flipped. If the short address was selected, the long address was set and vice versa.